### PR TITLE
:recycle: 유저정보 조회api 수정 및  상품조회 Caching 기능추가

### DIFF
--- a/src/main/java/com/kuku9/goods/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/kuku9/goods/domain/product/service/ProductServiceImpl.java
@@ -4,6 +4,7 @@ import com.kuku9.goods.domain.product.dto.ProductResponse;
 import com.kuku9.goods.domain.product.entity.Product;
 import com.kuku9.goods.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class ProductServiceImpl implements ProductService {
     private final ProductRepository productRepository;
 
     @Override
+    @Cacheable(value = "productCache", key = "#productId", unless = "#result == null")
     public ProductResponse getProduct(Long productId, String domainName) {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));

--- a/src/main/java/com/kuku9/goods/domain/seller/service/SellerServiceImpl.java
+++ b/src/main/java/com/kuku9/goods/domain/seller/service/SellerServiceImpl.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,7 @@ public class SellerServiceImpl implements SellerService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "productCache", key = "#productId")
     public Long updateProductStatus(Long productId, User user) {
         Seller seller = findSeller(user);
 
@@ -71,6 +73,7 @@ public class SellerServiceImpl implements SellerService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "productCache", key = "#productId")
     public Long updateProduct(
         Long productId, ProductUpdateRequest requestDto, User user) {
         Product product = findProduct(productId, findSeller(user));

--- a/src/main/java/com/kuku9/goods/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuku9/goods/domain/user/controller/UserController.java
@@ -41,13 +41,12 @@ public class UserController {
         return ResponseEntity.created(URI.create("/api/v1/auth/login")).build();
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping("/me")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_SELLER')")
     public ResponseEntity<UserResponse> getUserInfo(
-        @PathVariable Long userId,
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) throws AccessDeniedException {
-        UserResponse userResponse = userService.getUserInfo(userId, userDetails.getUser());
+        UserResponse userResponse = userService.getUserInfo(userDetails.getUser());
 
         return ResponseEntity.ok(userResponse);
     }

--- a/src/main/java/com/kuku9/goods/domain/user/service/UserService.java
+++ b/src/main/java/com/kuku9/goods/domain/user/service/UserService.java
@@ -39,11 +39,10 @@ public interface UserService {
     /**
      * 유저 정보 조회
      *
-     * @param userId 조회할 유저 아이디
      * @param user   유저
      * @return user 정보
      */
-    UserResponse getUserInfo(Long userId, User user) throws AccessDeniedException;
+    UserResponse getUserInfo(User user) throws AccessDeniedException;
 
     /**
      * 셀러등록

--- a/src/main/java/com/kuku9/goods/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/kuku9/goods/domain/user/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import com.kuku9.goods.global.exception.InvalidPasswordException;
 import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -56,6 +57,10 @@ public class UserServiceImpl implements UserService {
             throw new InvalidPasswordException(INVALID_PASSWORD);
         }
 
+        if(passwordEncoder.matches(request.getNewPassword(),findUser.getPassword())){
+            throw new InvalidPasswordException(SAME_PASSWORD_NOW_AND_NEW);
+        }
+
         findUser.modifyPassword(passwordEncoder.encode(request.getNewPassword()));
 
     }
@@ -72,6 +77,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "userCache", key = "#user.id")
     public Seller registerSeller(RegisterSellerRequest request, User user) {
 
         if (sellerService.checkSellerExistsByUserId(user.getId())) {

--- a/src/main/java/com/kuku9/goods/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/kuku9/goods/domain/user/service/UserServiceImpl.java
@@ -66,12 +66,10 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Cacheable(value = "userCache", key = "#userId", unless = "#result == null")
-    public UserResponse getUserInfo(Long userId, User user) throws AccessDeniedException {
-        User findUser = findById(userId);
-        if (!user.getId().equals(userId)) {
-            throw new AccessDeniedException(String.valueOf(NOT_EQUAL_USER_ID));
-        }
+    @Cacheable(value = "userCache", key = "#user.id", unless = "#result == null")
+    public UserResponse getUserInfo(User user) throws AccessDeniedException {
+        User findUser = findById(user.getId());
+
         return UserResponse.from(findUser);
     }
 

--- a/src/main/java/com/kuku9/goods/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/kuku9/goods/global/config/RedisCacheConfig.java
@@ -22,7 +22,7 @@ public class RedisCacheConfig {
         return RedisCacheManager.builder()
             .transactionAware()
             .cacheWriter(RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory))
-            .withCacheConfiguration("sellerCache", sellerCacheConfig())
+            .withCacheConfiguration("productCache", productCacheConfig())
             .withCacheConfiguration("userCache", userCacheConfig())
             .withCacheConfiguration("eventCache", eventCacheConfig())
             .cacheDefaults(defaultCacheConfig())
@@ -56,9 +56,9 @@ public class RedisCacheConfig {
     }
 
     @Bean
-    protected RedisCacheConfiguration sellerCacheConfig() {
+    protected RedisCacheConfiguration productCacheConfig() {
         return RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(10))
+            .entryTtl(Duration.ofMinutes(60))
             .serializeKeysWith(keySerialization())
             .serializeValuesWith(valueSerialization())
             .disableCachingNullValues();

--- a/src/main/java/com/kuku9/goods/global/exception/ExceptionStatus.java
+++ b/src/main/java/com/kuku9/goods/global/exception/ExceptionStatus.java
@@ -12,6 +12,7 @@ public enum ExceptionStatus {
     INVALID_ADMIN_CODE(HttpStatus.BAD_REQUEST.value(), "관리자 코드가 일치하지않습니다."),
     NO_SUCH_USER(HttpStatus.BAD_REQUEST.value(), "해당하는 유저 이름의 유저를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치 하지 않습니다."),
+    SAME_PASSWORD_NOW_AND_NEW(HttpStatus.BAD_REQUEST.value(), "현재 비밀번호와 같은 비밀번호로 변경할 수 없습니다."),
     NOT_EQUAL_USER_ID(HttpStatus.BAD_REQUEST.value(), "해당 정보는 유저본인만 확인할 수 있습니다."),
     DUPLICATED_SELLER(HttpStatus.BAD_REQUEST.value(), "셀러 등록은 중복으로 할 수 없습니다."),
     NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않습니다."),

--- a/src/main/java/com/kuku9/goods/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kuku9/goods/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.kuku9.goods.global.exception;
 
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -35,6 +36,7 @@ public class GlobalExceptionHandler {
             .body(ex.getMessage());
 
     }
+
 
     @ExceptionHandler(DuplicatedException.class)
     public ResponseEntity<String> duplicatedException(DuplicatedException ex) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
유저정보 api 요청시 pathvariable 로 조회하는 경우 대신 유저정보는 자기자신만 조회가 가능하다는 설계로 변경하여 /me endpoint로 수정하였습니다. 그리고 상품조회 기능부분에 Caching 기능을 추가하여 조회 성능 향상되었습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
